### PR TITLE
Use slider for heatmap, adjust initial rendering settings

### DIFF
--- a/patch_viewer/patches.py
+++ b/patch_viewer/patches.py
@@ -42,7 +42,7 @@ class Patches:
         ]
         return cls(coords, scores, counts, patch_size, labels)
 
-    def to_layer(
+    def as_layer(
         self, normalize=True, meta=RENDERING_DEFAULTS
     ) -> Tuple[np.ndarray, Dict, str]:
 

--- a/patch_viewer/plugin.py
+++ b/patch_viewer/plugin.py
@@ -50,4 +50,4 @@ def patch_reader(path: str):
     # Load patches
     patches = Patches.from_h5(path)
 
-    return [pyramid_layer, patches.to_layer()]
+    return [pyramid_layer, patches.as_layer()]


### PR DESCRIPTION
Adjust default rendering settings, make heatmap visible on load. Right now the labels are missing from the UI. 

@Richarizardd I will look into adding at least some references to the labels so show which heatmap is currently being displayed. Related issue: https://github.com/napari/napari/issues/14
